### PR TITLE
Adding logic to message send on expiry check script

### DIFF
--- a/scripts/expiry-scrape.py
+++ b/scripts/expiry-scrape.py
@@ -94,9 +94,11 @@ headers = {"Content-Type": "application/json"}
 
 # Get URL from env (mapped by Github action)
 webhook_url = os.environ["TEAMS_WEBHOOK_URL"]
-response = requests.post(webhook_url, headers=headers, data=card_json)
-
-if response.status_code == 200:
-  print("Card sent successfully!")
-else:
-  print("Error sending card: " + str(response.status_code))
+if expired_articles :
+  response = requests.post(webhook_url, headers=headers, data=card_json)
+  if response.status_code == 200:
+    print("Card sent successfully!")
+  else:
+    print("Error sending card: " + str(response.status_code))
+else: 
+  print("No expired articles detected, no message to send!")


### PR DESCRIPTION
As per title - stops the script that checks documentation for expired pages from dumping an empty message in teams if it doesn't find any. 