### PR TITLE
fix broken url for operations engineering

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          args: --verbose --exclude-mail --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429
+          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           

--- a/source/documentation/our_offer/tooling/index.html.md.erb
+++ b/source/documentation/our_offer/tooling/index.html.md.erb
@@ -54,6 +54,6 @@ A functional Azure DevOps project consists of multiple components to help manage
 ## Further reading and contacts
 
 - [What is Github and why is it used](https://docs.github.com/en/get-started/quickstart/hello-world)  
-- [MOJ Operations Engineering](https://operations-engineering.service.justice.gov.uk/#moj-operations-engineering) - owners of the MOJ Github organisation in terms of support, user management etc...  
+- [MOJ Operations Engineering](https://user-guide.operations-engineering.service.justice.gov.uk/) - owners of the MOJ Github organisation in terms of support, user management etc...  
 - [Getting started with Azure Devops](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/what-is-azure-pipelines?view=azure-devops)  
  


### PR DESCRIPTION
Fix broken URL for MoJ Operations Engineering which can be found on the [ALZ Tooling](https://ministryofjustice.github.io/azure-landing-zone-user-guides/documentation/our_offer/tooling/#further-reading-and-contacts) page in our user guides.
They migrated to a new URL "a while ago" which I was able to find on Slack and was correct as of March 2024.

Old URL:  https://operations-engineering.service.justice.gov.uk/#moj-operations-engineering
New URL:  https://user-guide.operations-engineering.service.justice.gov.uk/

Also removing the deprecated parameter `--exclude-mail` from the `lychee-action` code as per this warning:

_[WARN ] WARNING: `--exclude-mail` is deprecated and will soon be removed; E-Mail is no longer checked by default. Use `--include-mail` to enable E-Mail checking._