### PR TITLE
HC-1128 pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -9,11 +9,11 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.0.2
+        uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede # v2.0.2
         with:
           args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429
         env:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a # v4.4.0
         with:
           # Possible values: critical, high, moderate, low 
           fail-on-severity: critical

--- a/.github/workflows/doc-expiry-notify.yml
+++ b/.github/workflows/doc-expiry-notify.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Python3 Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: 3.10.10
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install dependencies
         run: |
@@ -25,5 +25,3 @@ jobs:
           TEAMS_WEBHOOK_URL: ${{ secrets.ALZ_NOTIFICATION_WEBHOOK }}
         run : |
           python scripts/expiry-scrape.py
-
-

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ministryofjustice/github-actions/code-formatter@v18.5.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ministryofjustice/github-actions/code-formatter@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,12 +26,12 @@ jobs:
       image: ministryofjustice/tech-docs-github-pages-publisher:v2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Compile Markdown to HTML and create artifact
         run: |
           /scripts/compile-and-create-artifact.sh
       - name: Upload artifact to be published
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@B4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: github-pages
           path: artifact.tar
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@main
+        uses: actions/deploy-pages@D6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Pin GitHub Actions to the specific full-length commit SHA for the desired version of the action.

As per Slack discussion in [#github-community](https://mojdt.slack.com/archives/C05L0KBA7RS/p1730199255440819)

And this guide: [https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide)

_Once a commit SHA is pinned, it guarantees that the specific code version cannot be altered. This offers significant security benefits compared to relying on version tags, which can be changed to point to different code versions._
