### PR TITLE
Fix the GitHub Actions semantic sha hashes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           /scripts/compile-and-create-artifact.sh
       - name: Upload artifact to be published
-        uses: actions/upload-artifact@B4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: github-pages
           path: artifact.tar
@@ -48,4 +48,4 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@D6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Updating `upload-artifact` to latest v4.6.0 and correcting the first letter of `deploy-pages` which had been capitalised causing Dependabot not to be able to recognise the version.
 
This is the error that this PR is resolving:
```
Dependabot could not resolve semantic versions for dependencies :
actions/upload-artifact, actions/deploy-pages
```